### PR TITLE
Minor updates to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ private_key_path = "/absolute/path/to/api/key/your_api_key.pem"
 ########## PROVIDER SPECIFIC VARIABLES ##########
 
 ########## ARTIFACT SPECIFIC VARIABLES ##########
-is_root_parent          = true
-root_compartment_ocid   = "ocid1.root.compartment"
+is_root_child           = true
 compartment_name        = "COMPARTMENT_NAME"
 compartment_description = "COMPARTMENT_DESCRIPTION"
 enable_delete           = true
@@ -66,7 +65,7 @@ sleep_timer  = 60
 ```
 
 ### Variable specific considerations
-- When creating a top level compartment depending on root, is mandatory that variable `is_root_compartment`is set to true and ocid of root compartment is passed on in variable `root_compartment_ocid`
+- When creating a top level compartment nested under on root, is mandatory that variable `is_root_child` is set to true.
 - In both cases, the variable `enable_delete` should be set to `true` if eventually compartments are required to be deleted programatically using terraform. This variable by default is `false`
 - You can nest up to six level of depness in compartments. Avoid using deeper nesting as IAM policies will fail to work
 - You can create as many compartments as needed, always respecting the nesting limitations
@@ -80,8 +79,9 @@ The following is the base provider definition to be used with this module
 
 ```shell
 terraform {
-  required_version = ">= 0.13.5"
+  required_version = ">= 1.0.0"
 }
+
 provider "oci" {
   region       = var.region
   tenancy_ocid = var.tenancy_ocid
@@ -108,7 +108,7 @@ provider "oci" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_oci"></a> [oci](#requirement\_oci) | >= 4.36.0 |
 
 ## Providers
@@ -140,11 +140,10 @@ No modules.
 | <a name="input_compartment_name"></a> [compartment\_name](#input\_compartment\_name) | Compartment Display Name | `any` | n/a | yes |
 | <a name="input_enable_delete"></a> [enable\_delete](#input\_enable\_delete) | Enables if Terraform is allowed to programatically delete this compartment upon invoking destroy command | `bool` | `false` | no |
 | <a name="input_fingerprint"></a> [fingerprint](#input\_fingerprint) | API Key Fingerprint for user\_ocid derived from public API Key imported in OCI User config | `any` | n/a | yes |
-| <a name="input_is_root_parent"></a> [is\_root\_parent](#input\_is\_root\_parent) | Boolean that describes if either the root compartment is the parent of this compartment or not | `bool` | `false` | no |
+| <a name="input_is_root_child"></a> [is\_root\_child](#input\_is\_root\_child) | Boolean that describes if the compartment is a child of root | `bool` | `false` | no |
 | <a name="input_parent_compartment_name"></a> [parent\_compartment\_name](#input\_parent\_compartment\_name) | Display name of Parent Compartment | `string` | `""` | no |
 | <a name="input_private_key_path"></a> [private\_key\_path](#input\_private\_key\_path) | Private Key Absolute path location where terraform is executed | `any` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Target region where artifacts are going to be created | `any` | n/a | yes |
-| <a name="input_root_compartment_ocid"></a> [root\_compartment\_ocid](#input\_root\_compartment\_ocid) | Root Compartment OCID Descriptor | `any` | `null` | no |
 | <a name="input_sleep_timer"></a> [sleep\_timer](#input\_sleep\_timer) | Sleep timer in seconds to wait for compartment to be created | `number` | `60` | no |
 | <a name="input_tenancy_ocid"></a> [tenancy\_ocid](#input\_tenancy\_ocid) | OCID of tenancy | `any` | n/a | yes |
 | <a name="input_user_ocid"></a> [user\_ocid](#input\_user\_ocid) | User OCID in tenancy. | `any` | n/a | yes |

--- a/compartment.tf
+++ b/compartment.tf
@@ -10,9 +10,10 @@ resource "oci_identity_compartment" "Compartment" {
   provider       = oci.home
   description    = var.compartment_description
   name           = var.compartment_name
-  compartment_id = var.is_root_parent == true ? var.root_compartment_ocid : local.parent_compartment_id
+  compartment_id = var.is_root_child ? var.tenancy_ocid : local.parent_compartment_id
   enable_delete  = var.enable_delete
 }
+
 resource "null_resource" "timer" {
   depends_on = [oci_identity_compartment.Compartment]
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,11 +35,6 @@ variable "parent_compartment_name" {
   default     = ""
 }
 
-variable "root_compartment_ocid" {
-  description = "Root Compartment OCID Descriptor"
-  default     = null
-}
-
 variable "compartment_name" {
   description = "Compartment Display Name"
 }
@@ -48,16 +43,14 @@ variable "compartment_description" {
   description = "Compartment Description"
 }
 
-variable "is_root_parent" {
-  description = "Boolean that describes if either the root compartment is the parent of this compartment or not"
+variable "is_root_child" {
+  description = "Boolean that describes if the compartment is a child of root"
   default     = false
-
 }
 
 variable "enable_delete" {
   description = "Enables if Terraform is allowed to programatically delete this compartment upon invoking destroy command"
   default     = false
-
 }
 
 variable "sleep_timer" {


### PR DESCRIPTION
- Changes naming of is_root_parent variable to make more sense - I know this is subjective on how you read this, but for example when you have is_flex_shape, its the perspective of the compute instance you're creating - when you have is_root_parent, it sounds like the compartment should be a parent of root (which is obviously not possible)
- Removes root_compartment_ocid variable as tenancy_ocid is always supplied already

These changes make it easier to work with ORM but also make more sense overall.