### PR TITLE
Fixes support for ORM

### DIFF
--- a/datasource.tf
+++ b/datasource.tf
@@ -28,5 +28,5 @@ data "oci_identity_region_subscriptions" "home_region_subscriptions" {
 locals {
   release = "1.0"
   # Compartment OCID Local Accessor
-  parent_compartment_id = length(data.oci_identity_compartments.PARENTCOMPARTMENT.compartments) > 0 ? lookup(data.oci_identity_compartments.PARENTCOMPARTMENT.compartments[0], "id") : null
+  parent_compartment_id = length(regexall("ocid", var.parent_compartment_name)) > 0 ? var.parent_compartment_name : (length(data.oci_identity_compartments.PARENTCOMPARTMENT.compartments) > 0 ? data.oci_identity_compartments.PARENTCOMPARTMENT.compartments[0].id : "")
 }


### PR DESCRIPTION
This fix allows for the parent compartment name to be passed as an OCID or by name. 

This is because ORM passes compartments by OCID but CloudBricks used compartment names.